### PR TITLE
[codex] Clean main branch references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Buffered C line reader for UNIX file descriptors.
 
-[![CI](https://img.shields.io/github/actions/workflow/status/itkrivoshei/get-next-line-c/ci.yml?branch=master&style=for-the-badge&label=ci&logo=githubactions&logoColor=white)](https://github.com/itkrivoshei/get-next-line-c/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/itkrivoshei/get-next-line-c/ci.yml?branch=main&style=for-the-badge&label=ci&logo=githubactions&logoColor=white)](https://github.com/itkrivoshei/get-next-line-c/actions/workflows/ci.yml)
 [![C](https://img.shields.io/badge/C-89%20style-555?style=for-the-badge&logo=c&logoColor=white)](get_next_line.c)
 [![Make](https://img.shields.io/badge/Make-build-427819?style=for-the-badge&logo=gnu&logoColor=white)](Makefile)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue?style=for-the-badge)](LICENSE)


### PR DESCRIPTION
## Summary
- Removed temporary master workflow support and updated the CI badge to main.
- Finishes the post-rename cleanup for the repository.

## Validation
- Local: make && make test && make fclean passed.
