### PR TITLE
fix: repair CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-          uses: github/codeql-action/init@v6
+        uses: github/codeql-action/init@v4
         with:
           languages: actions
           queries: "+security-extended"
 
       - name: Perform CodeQL analysis
-          uses: github/codeql-action/analyze@v6
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:actions"
 
@@ -49,13 +49,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-          uses: github/codeql-action/init@v6
+        uses: github/codeql-action/init@v4
         with:
           languages: c-cpp
           build-mode: none
           queries: "+security-extended"
 
       - name: Perform CodeQL analysis
-          uses: github/codeql-action/analyze@v6
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
## What changed
- Fixed invalid YAML indentation in the CodeQL workflow steps.\n- Updated unsupported CodeQL Action v6 references to supported v4.

## Why
GitHub Actions could not resolve `github/codeql-action@v6`, causing CodeQL runs to fail before analysis.

## What was intentionally not changed
- Application code
- README content
- Dependabot configuration
- Package manager and lockfiles

## Validation
- YAML parsed with PyYAML\n- make test\n- make fclean cleanup

## GitHub checks
Pending on this PR.